### PR TITLE
refactor TRI-27: 내 체험 등록/수정 페이지 공통 폼 개선사항 반영, 토스트 유틸 추가

### DIFF
--- a/src/components/pages/myActivities/CategorySelect.tsx
+++ b/src/components/pages/myActivities/CategorySelect.tsx
@@ -6,16 +6,28 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select';
+import { ActivitiesCategoryType } from '@/types/activities.type';
+import clsx from 'clsx';
+import { FieldError } from 'react-hook-form';
 
 interface CategorySelectProps {
   value: string;
+  error?: FieldError;
   onChange: (val: string) => void;
   onBlur: () => void;
+  className?: string;
 }
 
-const categories = ['문화 · 예술', '식음료', '스포츠', '투어', '관광', '웰빙'];
+const categories: ActivitiesCategoryType[] = [
+  '문화 · 예술',
+  '식음료',
+  '스포츠',
+  '투어',
+  '관광',
+  '웰빙',
+];
 
-const CategorySelect = ({ value, onChange, onBlur }: CategorySelectProps) => {
+const CategorySelect = ({ value, error, onChange, onBlur, className }: CategorySelectProps) => {
   return (
     <Select
       value={value}
@@ -26,8 +38,13 @@ const CategorySelect = ({ value, onChange, onBlur }: CategorySelectProps) => {
         }
       }}
     >
-      <SelectTrigger className='w-full'>
-        <SelectValue placeholder='카테고리를 선택해 주세요' />
+      <SelectTrigger
+        className={clsx('w-full', className, error && 'data-[placeholder]:text-destructive/50')}
+      >
+        <SelectValue
+          placeholder='카테고리를 선택해 주세요'
+          className={clsx(error && 'placeholder:text-destructive/50')}
+        />
       </SelectTrigger>
       <SelectContent>
         <SelectGroup>

--- a/src/components/pages/myActivities/ImageUploadSection.tsx
+++ b/src/components/pages/myActivities/ImageUploadSection.tsx
@@ -1,0 +1,108 @@
+import { Label } from '@/components/ui/label';
+import useMyActivityForm from '@/hooks/useMyActivityForm';
+import { MyActivityFormData } from '@/lib/utils/myActivitySchema';
+import { Control, Controller } from 'react-hook-form';
+import ImageUploader from './ImageUploader';
+import { SubImage } from '@/types/activities.type';
+
+interface ImageUploadSectionProps {
+  control: Control<MyActivityFormData>;
+  methods: ReturnType<typeof useMyActivityForm>['methods'];
+  setValue: ReturnType<typeof useMyActivityForm>['setValue'];
+}
+
+const ImageUploadSection = ({ control, methods, setValue }: ImageUploadSectionProps) => {
+  return (
+    <div className='flex flex-col gap-7.5 mt-5'>
+      <div className='flex flex-col'>
+        <Label>배너 이미지 등록</Label>
+        <span className='text-12-regular text-grayscale-500 py-1'>
+          <span className='text-primary-500 mr-0.5'>*</span>배너 이미지는 필수입니다
+        </span>
+        <Controller
+          name='bannerFiles'
+          control={control}
+          rules={{ required: '배너 이미지를 업로드해주세요' }}
+          render={({ field, fieldState }) => (
+            <div>
+              <ImageUploader
+                maxImages={1}
+                files={field.value || []}
+                fetchedImages={
+                  methods.getValues('bannerImages')?.length ? methods.getValues('bannerImages') : []
+                }
+                onChange={(val) => {
+                  field.onChange(val);
+                  field.onBlur();
+                }}
+                onDeleteFetched={() => {
+                  setValue('bannerImageUrl', '', {
+                    shouldValidate: true,
+                    shouldDirty: true,
+                  });
+                  methods.setValue('bannerImages', [], {
+                    shouldDirty: true,
+                    shouldValidate: true,
+                  });
+                  field.onChange([]);
+                }}
+              />
+              {fieldState.error && (
+                <small className='text-12-medium ml-2 text-[var(--secondary-red-500)] mt-[6px] leading-[12px]'>
+                  {fieldState.error.message}
+                </small>
+              )}
+            </div>
+          )}
+        />
+      </div>
+
+      <div className='flex flex-col'>
+        <Label>소개 이미지 등록</Label>
+        <span className='text-12-regular text-grayscale-500 py-1'>
+          <span className='text-primary-500 mr-0.5'>*</span>소개 이미지는 최소 2개 이상 등록해주세요
+        </span>
+        <Controller
+          name='subFiles'
+          control={control}
+          rules={{ required: '배너 이미지를 업로드해주세요' }}
+          render={({ field, fieldState }) => (
+            <div>
+              <ImageUploader
+                files={field.value || []}
+                fetchedImages={methods.getValues('subImages')}
+                onChange={(val) => field.onChange(val)}
+                onDeleteFetched={(id) => {
+                  if (id !== undefined) {
+                    const prev = methods.getValues('subImageIdsToRemove') || [];
+                    methods.setValue('subImageIdsToRemove', [...prev, id], {
+                      shouldDirty: true,
+                      shouldValidate: true,
+                    });
+
+                    // subImages 배열에서 삭제
+                    const prevImages = (methods.getValues('subImages') as SubImage[]) || [];
+                    const newImages = prevImages.filter((img) => img.id !== id);
+                    methods.setValue('subImages', newImages, {
+                      shouldDirty: true,
+                      shouldValidate: true,
+                    });
+
+                    field.onChange([]);
+                  }
+                }}
+              />
+              {fieldState.error && (
+                <small className='text-12-medium ml-2 text-[var(--secondary-red-500)] mt-[6px] leading-[12px]'>
+                  {fieldState.error.message}
+                </small>
+              )}
+            </div>
+          )}
+        />
+      </div>
+    </div>
+  );
+};
+
+export default ImageUploadSection;

--- a/src/components/pages/myActivities/ImageUploader.tsx
+++ b/src/components/pages/myActivities/ImageUploader.tsx
@@ -27,9 +27,10 @@ const ImageUploader = ({
   const inputRef = useRef<HTMLInputElement>(null);
 
   const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    console.log('파일 change');
     if (!e.target.files) return;
-    const fileList = Array.from(e.target.files);
 
+    const fileList = Array.from(e.target.files);
     const newImages = [...fileList, ...files].slice(0, maxImages);
     onChange?.(newImages);
     e.target.value = '';
@@ -118,7 +119,7 @@ const ImageUploader = ({
       <input
         ref={inputRef}
         type='file'
-        accept='image/*'
+        accept='image/png, image/jpeg'
         multiple
         className='hidden'
         onChange={handleFileChange}

--- a/src/components/pages/myActivities/ImageUploader.tsx
+++ b/src/components/pages/myActivities/ImageUploader.tsx
@@ -27,7 +27,6 @@ const ImageUploader = ({
   const inputRef = useRef<HTMLInputElement>(null);
 
   const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    console.log('파일 change');
     if (!e.target.files) return;
 
     const fileList = Array.from(e.target.files);

--- a/src/components/pages/myActivities/MyActivityForm.tsx
+++ b/src/components/pages/myActivities/MyActivityForm.tsx
@@ -14,7 +14,7 @@ import { Button } from '@/components/ui/button';
 import { Textarea } from '@/components/ui/textarea';
 import CategorySelect from './CategorySelect';
 import Script from 'next/script';
-import { MyActivityFormData } from '@/types/myActivitySchema';
+import { MyActivityFormData } from '@/lib/utils/myActivitySchema';
 import FormInput from '@/components/common/FormInput';
 import clsx from 'clsx';
 import { MyActivitySchedule } from '@/types/myActivity.types';
@@ -214,6 +214,7 @@ const MyActivityForm = ({ mode = 'REGISTER', activityId }: MyActivityFormProps) 
                 label='제목'
                 placeholder='제목을 입력해 주세요'
                 error={errors.title?.message}
+                maxLength={20}
                 {...register('title')}
               />
             </div>
@@ -229,11 +230,16 @@ const MyActivityForm = ({ mode = 'REGISTER', activityId }: MyActivityFormProps) 
                   <div>
                     <CategorySelect
                       value={field.value ?? undefined}
+                      error={fieldState.error}
                       onChange={field.onChange}
                       onBlur={() => {
                         field.onBlur();
                         trigger('category');
                       }}
+                      className={
+                        fieldState.error &&
+                        'border-destructive/20 bg-destructive/10 dark:bg-destructive/20'
+                      }
                     />
                     {fieldState.error && (
                       <small className='text-12-medium ml-2 text-[var(--secondary-red-500)] mt-[6px] leading-[12px]'>

--- a/src/components/pages/myActivities/MyActivityForm.tsx
+++ b/src/components/pages/myActivities/MyActivityForm.tsx
@@ -9,21 +9,18 @@ import {
   Merge,
 } from 'react-hook-form';
 import { Label } from '@/components/ui/label';
-import ImageUploader from '@/components/pages/myActivities/ImageUploader';
 import { Button } from '@/components/ui/button';
 import { Textarea } from '@/components/ui/textarea';
 import CategorySelect from './CategorySelect';
-import Script from 'next/script';
 import { MyActivityFormData } from '@/lib/utils/myActivitySchema';
 import FormInput from '@/components/common/FormInput';
 import clsx from 'clsx';
 import { MyActivitySchedule } from '@/types/myActivity.types';
-import { ActivityCreateRequest, ActivityUpdateRequest } from '@/app/api/activities';
-import { ActivitiesCategoryType } from '@/types/activities.type';
-import { useEffect, useState } from 'react';
-import { toApiDate, toInputDate } from '@/lib/utils/dateUtils';
-import { SubImage } from '@/types/activities.types';
+import { useEffect } from 'react';
+import { toInputDate } from '@/lib/utils/dateUtils';
 import useMyActivityForm from '@/hooks/useMyActivityForm';
+import ImageUploadSection from './ImageUploadSection';
+import Script from 'next/script';
 
 interface MyActivityFormProps {
   mode?: 'EDIT' | 'REGISTER';
@@ -38,44 +35,16 @@ const MyActivityForm = ({ mode = 'REGISTER', activityId }: MyActivityFormProps) 
     scheduleFields,
     register,
     setValue,
-    watch,
     trigger,
     update,
     append,
     remove,
     getDetailMutation,
-    uploadImageMutation,
-    registerMutation,
-    updateMutation,
-  } = useMyActivityForm();
-  const [originalSchedules, setOriginalSchedules] = useState<MyActivityFormData['schedules']>([]);
-
-  const uploadImageAndGetUrl = async () => {
-    const bannerFiles = watch('bannerFiles') ?? [];
-    const subFiles = watch('subFiles') ?? [];
-
-    if (bannerFiles.length > 0) {
-      const bannerUploadResponse = await uploadImageMutation.mutateAsync(bannerFiles[0]);
-      setValue('bannerImageUrl', bannerUploadResponse.activityImageUrl, {
-        shouldValidate: true,
-        shouldDirty: true,
-      });
-    }
-
-    if (subFiles.length > 0) {
-      const subImagesUploadResponse = await Promise.all(
-        subFiles.map((file) => uploadImageMutation.mutateAsync(file)),
-      );
-
-      const subImageUrls = subImagesUploadResponse.map((res) => res.activityImageUrl);
-
-      if (mode === 'EDIT') {
-        setValue('subImageUrlsToAdd', subImageUrls, { shouldValidate: true, shouldDirty: true });
-      } else {
-        setValue('subImageUrls', subImageUrls, { shouldValidate: true, shouldDirty: true });
-      }
-    }
-  };
+    uploadImageAndGetUrl,
+    registerForm,
+    updateForm,
+    setOriginalSchedules,
+  } = useMyActivityForm({ mode, activityId });
 
   const handleOpenAddressSearch = () => {
     new window.daum.Postcode({
@@ -84,74 +53,6 @@ const MyActivityForm = ({ mode = 'REGISTER', activityId }: MyActivityFormProps) 
         setValue('address', addr, { shouldValidate: true });
       },
     }).open();
-  };
-
-  const registerForm = async () => {
-    const values = methods.getValues();
-
-    const params: ActivityCreateRequest = {
-      ...values,
-      category: values.category as ActivitiesCategoryType,
-      price: Number(values.price.replace(/,/g, '')),
-      subImageUrls: values.subImageUrls ?? [],
-      schedules: values.schedules.map(({ date, startTime, endTime }) => ({
-        date: toApiDate(date),
-        startTime,
-        endTime,
-      })),
-    };
-
-    registerMutation.mutate(params);
-  };
-
-  const updateForm = async () => {
-    const values = methods.getValues();
-
-    // 삭제된 스케줄
-    const scheduleIdsToRemove: number[] = originalSchedules
-      .filter((s) => {
-        const current = values.schedules.find((v) => v.id === s.id);
-        if (!current) return true;
-
-        return (
-          current.date !== s.date ||
-          current.startTime !== s.startTime ||
-          current.endTime !== s.endTime
-        );
-      })
-      .map((s) => Number(s.id));
-
-    // 새로 추가된 스케줄
-    const schedulesToAdd = values.schedules
-      .filter((s) => {
-        if (!s.id) return true;
-
-        const original = originalSchedules.find((v) => v.id === s.id);
-        if (!original) return true;
-
-        return (
-          original.date !== s.date ||
-          original.startTime !== s.startTime ||
-          original.endTime !== s.endTime
-        );
-      })
-      .map(({ date, startTime, endTime }) => ({
-        date: toApiDate(date),
-        startTime,
-        endTime,
-      }));
-
-    const params: ActivityUpdateRequest = {
-      ...values,
-      category: values.category as ActivitiesCategoryType,
-      price: Number(values.price.replace(/,/g, '')),
-      scheduleIdsToRemove,
-      schedulesToAdd,
-      subImageIdsToRemove: values.subImageIdsToRemove ?? [],
-      subImageUrlsToAdd: values.subImageUrlsToAdd ?? [],
-    };
-
-    updateMutation.mutate({ activityId: Number(activityId), data: params });
   };
 
   const onSubmit = async (data: MyActivityFormData) => {
@@ -370,103 +271,7 @@ const MyActivityForm = ({ mode = 'REGISTER', activityId }: MyActivityFormProps) 
           </div>
 
           {/* 이미지 등록 */}
-          <div className='flex flex-col gap-7.5 mt-5'>
-            <div className='flex flex-col'>
-              <Label>배너 이미지 등록</Label>
-              <span className='text-12-regular text-grayscale-500 py-1'>
-                <span className='text-primary-500 mr-0.5'>*</span>배너 이미지는 필수입니다
-              </span>
-              <Controller
-                name='bannerFiles'
-                control={control}
-                rules={{ required: '배너 이미지를 업로드해주세요' }}
-                render={({ field, fieldState }) => (
-                  <div>
-                    <ImageUploader
-                      maxImages={1}
-                      files={field.value || []}
-                      fetchedImages={
-                        methods.getValues('bannerImages')?.length
-                          ? methods.getValues('bannerImages')
-                          : []
-                      }
-                      onChange={(val) => {
-                        field.onChange(val);
-                        field.onBlur();
-                      }}
-                      onDeleteFetched={() => {
-                        setValue('bannerImageUrl', '', {
-                          shouldValidate: true,
-                          shouldDirty: true,
-                        });
-                        methods.setValue('bannerImages', [], {
-                          shouldDirty: true,
-                          shouldValidate: true,
-                        });
-                        field.onChange([]);
-                      }}
-                    />
-                    {fieldState.error && (
-                      <small className='text-12-medium ml-2 text-[var(--secondary-red-500)] mt-[6px] leading-[12px]'>
-                        {fieldState.error.message}
-                      </small>
-                    )}
-                  </div>
-                )}
-              />
-            </div>
-
-            <div className='flex flex-col'>
-              <Label>소개 이미지 등록</Label>
-              <span className='text-12-regular text-grayscale-500 py-1'>
-                <span className='text-primary-500 mr-0.5'>*</span>소개 이미지는 최소 2개 이상
-                등록해주세요
-              </span>
-              <Controller
-                name='subFiles'
-                control={control}
-                rules={{ required: '배너 이미지를 업로드해주세요' }}
-                render={({ field, fieldState }) => (
-                  <div>
-                    <ImageUploader
-                      files={field.value || []}
-                      fetchedImages={methods.getValues('subImages')}
-                      onChange={(val) => field.onChange(val)}
-                      onDeleteFetched={(id) => {
-                        if (id !== undefined) {
-                          const prev = methods.getValues('subImageIdsToRemove') || [];
-                          methods.setValue('subImageIdsToRemove', [...prev, id], {
-                            shouldDirty: true,
-                            shouldValidate: true,
-                          });
-
-                          // subImages 배열에서 삭제
-                          const prevImages = (methods.getValues('subImages') as SubImage[]) || [];
-                          const newImages = prevImages.filter((img) => img.id !== id);
-                          methods.setValue('subImages', newImages, {
-                            shouldDirty: true,
-                            shouldValidate: true,
-                          });
-
-                          field.onChange([]);
-                        }
-                      }}
-                    />
-                    {fieldState.error && (
-                      <small className='text-12-medium ml-2 text-[var(--secondary-red-500)] mt-[6px] leading-[12px]'>
-                        {fieldState.error.message}
-                      </small>
-                    )}
-                  </div>
-                )}
-              />
-            </div>
-            {/* 다음 주소 API 스크립트 */}
-            <Script
-              src='//t1.daumcdn.net/mapjsapi/bundle/postcode/prod/postcode.v2.js'
-              strategy='afterInteractive'
-            />
-          </div>
+          <ImageUploadSection control={control} methods={methods} setValue={setValue} />
 
           <div className='flex justify-center w-full mt-6'>
             <Button
@@ -479,6 +284,12 @@ const MyActivityForm = ({ mode = 'REGISTER', activityId }: MyActivityFormProps) 
           </div>
         </form>
       </FormProvider>
+
+      {/* 다음 주소 API 스크립트 */}
+      <Script
+        src='//t1.daumcdn.net/mapjsapi/bundle/postcode/prod/postcode.v2.js'
+        strategy='afterInteractive'
+      />
     </div>
   );
 };

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -31,7 +31,7 @@ function SelectTrigger({
       data-slot='select-trigger'
       data-size={size}
       className={cn(
-        "border-[var(--grayscale-100)] data-[placeholder]:text-muted-foreground [&_svg:not([class*='text-'])]:text-muted-foreground focus-visible:border-[var(--primary-200)] focus-visible:ring-[var(--primary-200)]/30 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 dark:hover:bg-input/50 flex w-fit items-center justify-between gap-2 rounded-xl border bg-transparent px-5 py-[17px] text-sm whitespace-nowrap transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-2 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "border-[var(--grayscale-100)] data-[placeholder]:text-muted-foreground [&_svg:not([class*='text-'])]:text-muted-foreground focus-visible:border-[var(--primary-200)] focus-visible:ring-[var(--primary-200)]/30 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 dark:hover:bg-input/50 flex w-fit items-center justify-between gap-2 rounded-xl border bg-transparent px-5 py-[17px] whitespace-nowrap transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-2 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
         className,
       )}
       {...props}
@@ -98,7 +98,7 @@ function SelectItem({
     <SelectPrimitive.Item
       data-slot='select-item'
       className={cn(
-        "focus:bg-primary-100 focus:text-accent-foreground [&_svg:not([class*='text-'])]:text-muted-foreground relative flex w-full cursor-default items-center gap-2 rounded-sm py-1.5 pr-8 pl-2 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 *:[span]:last:flex *:[span]:last:items-center *:[span]:last:gap-2",
+        "focus:bg-primary-100 focus:text-accent-foreground [&_svg:not([class*='text-'])]:text-muted-foreground relative flex w-full cursor-default items-center gap-2 rounded-sm py-1.5 pr-8 pl-2 text-base outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 *:[span]:last:flex *:[span]:last:items-center *:[span]:last:gap-2",
         className,
       )}
       {...props}

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -12,7 +12,9 @@ const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
         <textarea
           ref={ref}
           className={cn(
-            'resize-none border placeholder:text-muted-foreground focus-visible:border-[var(--primary-200)] focus-visible:ring-[var(--primary-200)]/30 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 aria-invalid:border-destructive flex min-h-16 w-full rounded-xl bg-transparent px-5 py-4 text-sm outline-none disabled:cursor-not-allowed disabled:opacity-50',
+            'resize-none border placeholder:text-muted-foreground focus-visible:border-[var(--primary-200)] focus-visible:ring-[var(--primary-200)]/30 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 aria-invalid:border-destructive flex min-h-16 w-full rounded-xl bg-transparent px-5 py-4 text-base outline-none disabled:cursor-not-allowed disabled:opacity-50',
+            error &&
+              'border-destructive/20 bg-destructive/10 dark:bg-destructive/20 placeholder:text-destructive/50',
             className,
           )}
           {...props}

--- a/src/hooks/useMyActivityForm.tsx
+++ b/src/hooks/useMyActivityForm.tsx
@@ -17,6 +17,7 @@ import { ActivitiesCategoryType, ActivityDetail } from '@/types/activities.type'
 import { successToast } from '@/lib/utils/toastUtils';
 import { toApiDate } from '@/lib/utils/dateUtils';
 import { useState } from 'react';
+import { useRouter } from 'next/navigation';
 
 interface useMyActivityForm {
   mode?: 'EDIT' | 'REGISTER';
@@ -24,6 +25,7 @@ interface useMyActivityForm {
 }
 
 const useMyActivityForm = ({ mode = 'REGISTER', activityId }: useMyActivityForm) => {
+  const router = useRouter();
   const [originalSchedules, setOriginalSchedules] = useState<MyActivityFormData['schedules']>([]);
 
   const methods = useForm({
@@ -92,7 +94,8 @@ const useMyActivityForm = ({ mode = 'REGISTER', activityId }: useMyActivityForm)
     mutationFn: (data: ActivityCreateRequest) => createActivity(data),
     retry: 1,
     retryDelay: 300,
-    onSuccess: () => {
+    onSuccess: (response) => {
+      router.push(`/activities/${response.id}`);
       successToast.run('등록이 완료되었습니다.');
     },
     onError: (error) => {
@@ -108,7 +111,8 @@ const useMyActivityForm = ({ mode = 'REGISTER', activityId }: useMyActivityForm)
     mutationFn: ({ activityId, data }) => updateActivity(activityId, data),
     retry: 1,
     retryDelay: 300,
-    onSuccess: () => {
+    onSuccess: (response) => {
+      router.push(`/activities/${response.id}`);
       successToast.run('수정이 완료되었습니다.');
     },
     onError: (error) => {

--- a/src/hooks/useMyActivityForm.tsx
+++ b/src/hooks/useMyActivityForm.tsx
@@ -1,6 +1,6 @@
 import { useFieldArray, useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
-import { MyActivitySchema } from '@/types/myActivitySchema';
+import { MyActivitySchema } from '@/lib/utils/myActivitySchema';
 import { useMutation } from '@tanstack/react-query';
 import {
   ActivityCreateRequest,
@@ -13,21 +13,10 @@ import {
   updateActivity,
   uploadActivityImage,
 } from '@/app/api/activities';
-import { createToast } from 'react-simplified-package';
-import { FaCheckCircle } from 'react-icons/fa';
 import { ActivityDetail } from '@/types/activities.type';
+import { errorToast, successToast } from '@/lib/utils/toastUtils';
 
 const useMyActivityForm = () => {
-  const successToast = createToast(
-    (str) => (
-      <div className='flex items-center text-green-500 border border-green-500 p-4 rounded-lg bg-white shadow-md'>
-        <FaCheckCircle className='mr-1' />
-        <span className='text-xs'>{str}이 완료되었습니다.</span>
-      </div>
-    ),
-    { duration: 3000 },
-  );
-
   const methods = useForm({
     resolver: zodResolver(MyActivitySchema),
     defaultValues: {
@@ -95,7 +84,7 @@ const useMyActivityForm = () => {
     retry: 1,
     retryDelay: 300,
     onSuccess: () => {
-      successToast.run('등록');
+      successToast.run('등록이 완료되었습니다.');
     },
     onError: (error) => {
       console.log('업로드 실패', error);
@@ -111,7 +100,7 @@ const useMyActivityForm = () => {
     retry: 1,
     retryDelay: 300,
     onSuccess: () => {
-      successToast.run('수정');
+      successToast.run('수정이 완료되었습니다.');
     },
     onError: (error) => {
       console.log('업로드 실패', error);
@@ -135,6 +124,8 @@ const useMyActivityForm = () => {
     uploadImageMutation,
     registerMutation,
     updateMutation,
+    successToast,
+    errorToast,
   };
 };
 

--- a/src/lib/utils/toastUtils.tsx
+++ b/src/lib/utils/toastUtils.tsx
@@ -14,7 +14,9 @@ const toastIconMap = {
 const createToastWithType = (type: 'success' | 'error') => {
   return createToast(
     (str) => (
-      <div className={`flex items-center p-4 rounded-lg bg-white shadow-md ${toastTypeMap[type]}`}>
+      <div
+        className={`flex items-center p-4 rounded-lg bg-white shadow-md border ${toastTypeMap[type]}`}
+      >
         {toastIconMap[type]}
         <span className='text-xs'>{str}</span>
       </div>

--- a/src/lib/utils/toastUtils.tsx
+++ b/src/lib/utils/toastUtils.tsx
@@ -1,0 +1,27 @@
+import { createToast } from 'react-simplified-package';
+import { FaCheckCircle, FaExclamationTriangle } from 'react-icons/fa';
+
+const toastTypeMap = {
+  success: 'text-green-500 border-green-500',
+  error: 'text-[var(--secondary-red-500)] border-[var(--secondary-red-500)]',
+} as const;
+
+const toastIconMap = {
+  success: <FaCheckCircle className='mr-1' />,
+  error: <FaExclamationTriangle className='mr-1' />,
+} as const;
+
+const createToastWithType = (type: 'success' | 'error') => {
+  return createToast(
+    (str) => (
+      <div className={`flex items-center p-4 rounded-lg bg-white shadow-md ${toastTypeMap[type]}`}>
+        {toastIconMap[type]}
+        <span className='text-xs'>{str}</span>
+      </div>
+    ),
+    { duration: 3000 },
+  );
+};
+
+export const successToast = createToastWithType('success');
+export const errorToast = createToastWithType('error');


### PR DESCRIPTION
# 📦 Pull Request

## 📝 요약(Summary)

<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
**공통 파일**
- `토스트 유틸` 파일 추가 (toastUtils.tsx)

**체험 등록/수정 관련**
- 체험 관리 등록/수정 공통 폼 (MyActivityForm.tsx)
- 체험 관리 폼용 훅 (useMyActivityForm.tsx)
- 제목 maxLength 20글자 제한

- 이미지 업로드 영역 섹션 분리 (ImageUploadSection)
- 이미지 업로드 시 jpg, png만 업로드 가능하게 수정 (ImageUploader)

- 등록/수정 시 상세화면으로 이동하게 변경
- 오늘 이전 날짜 입력 시 validation 추가
- select, textarea 에러 시 디자인 수정

## 💬 공유사항 to 리뷰어

<!--
이 PR에서 집중적으로 리뷰 받고 싶은 부분이나
논의가 필요한 사항을 작성해주세요.
예시: 함수명, 컴포넌트 구조, 성능 최적화 아이디어 등
-->

해당 파일 위주로 확인 부탁드립니다!
- 체험 관리 등록/수정 공통 폼 (MyActivityForm.tsx)
- 체험 관리 폼용 훅 (useMyActivityForm.tsx)

## 📸 스크린샷

<!-- UI/UX 변경 시 필수로 첨부 -->
