### PR TITLE
feat TRI-28: 내 체험 관리 페이지 내 사이드메뉴 컴포넌트 개발

### DIFF
--- a/src/app/mypage/layout.tsx
+++ b/src/app/mypage/layout.tsx
@@ -1,0 +1,20 @@
+'use client';
+import SideMenu from '@/components/pages/myPage/SideMenu';
+import { useScreenSize } from '@/hooks/useScreenSize';
+import { ReactNode } from 'react';
+
+interface MyPageCommonLayoutProps {
+  children: ReactNode;
+}
+
+const MyPageCommonLayout = ({ children }: MyPageCommonLayoutProps) => {
+  const { isMobile } = useScreenSize();
+  return (
+    <div className='flex max-w-[327px] md:max-w-[684px] lg:max-w-[980px] mx-auto py-7.5 gap-7.5 lg:gap-12.5'>
+      {!isMobile && <SideMenu />}
+      {children}
+    </div>
+  );
+};
+
+export default MyPageCommonLayout;

--- a/src/app/mypage/my-experience/page.tsx
+++ b/src/app/mypage/my-experience/page.tsx
@@ -1,0 +1,5 @@
+const MyExperiencePage = () => {
+  return <div>내 체험 관리 페이지</div>;
+};
+
+export default MyExperiencePage;

--- a/src/app/mypage/page.tsx
+++ b/src/app/mypage/page.tsx
@@ -1,0 +1,12 @@
+import SideMenu from '@/components/pages/myPage/SideMenu';
+
+const MyPage = () => {
+  {
+    /* 모바일에서 마이페이지 링크 */
+  }
+  <div>
+    <SideMenu />
+  </div>;
+};
+
+export default MyPage;

--- a/src/app/mypage/reservation-list/page.tsx
+++ b/src/app/mypage/reservation-list/page.tsx
@@ -1,0 +1,5 @@
+const ReservationListPage = () => {
+  return <div>예약 현황 페이지</div>;
+};
+
+export default ReservationListPage;

--- a/src/app/mypage/reservation-status/page.tsx
+++ b/src/app/mypage/reservation-status/page.tsx
@@ -1,0 +1,5 @@
+const ReservationStatusPage = () => {
+  return <div>체험 현황 페이지</div>;
+};
+
+export default ReservationStatusPage;

--- a/src/app/mypage/user/page.tsx
+++ b/src/app/mypage/user/page.tsx
@@ -1,0 +1,5 @@
+const UserPage = () => {
+  return <div>내 정보 페이지</div>;
+};
+
+export default UserPage;

--- a/src/components/pages/myActivities/RoundButton.tsx
+++ b/src/components/pages/myActivities/RoundButton.tsx
@@ -2,10 +2,10 @@ import { ButtonHTMLAttributes } from 'react';
 
 import clsx from 'clsx';
 
-import { FaPlus, FaMinus, FaTimes } from 'react-icons/fa';
+import { FaPlus, FaMinus, FaTimes, FaPen } from 'react-icons/fa';
 
 interface RoundButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
-  mode?: 'plus' | 'minus' | 'close';
+  mode?: 'plus' | 'minus' | 'close' | 'edit';
   children?: React.ReactNode;
   className?: string;
   onClick?: () => void;
@@ -20,6 +20,7 @@ const RoundButton = ({ mode = 'close', children, className, onClick }: RoundButt
       plus: 'w-[28px] h-[28px] sm:w-[42px] sm:h-[42px] bg-primary-500 hover:bg-[var(--primary-400)]',
       minus: 'w-[28px] h-[28px] sm:w-[42px] sm:h-[42px] bg-grayscale-50 hover:bg-grayscale-25',
       close: 'w-[20px] h-[20px] sm:w-[26px] sm:h-[26px] bg-grayscale-950 hover:bg-grayscale-800',
+      edit: 'w-[30px] h-[30px] md:w-[24px] md:h-[24px] lg:w-[30px] lg:h-[30px] bg-grayscale-300 hover:bg-grayscale-200',
     };
     return modeClassMap[mode];
   };
@@ -29,6 +30,7 @@ const RoundButton = ({ mode = 'close', children, className, onClick }: RoundButt
       {mode === 'plus' && <FaPlus size={12} className='text-white' />}
       {mode === 'minus' && <FaMinus size={12} className='text-black' />}
       {mode === 'close' && <FaTimes size={10} className='text-white' />}
+      {mode === 'edit' && <FaPen size={10} className='text-white' />}
       {children}
     </button>
   );

--- a/src/components/pages/myPage/SideMenu.tsx
+++ b/src/components/pages/myPage/SideMenu.tsx
@@ -1,0 +1,72 @@
+import { Card } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+
+import { FaUser, FaCommentDots, FaCog, FaCalendarAlt } from 'react-icons/fa';
+import Image from 'next/image';
+import RoundButton from '../myActivities/RoundButton';
+import clsx from 'clsx';
+import Link from 'next/link';
+
+interface SideMenuProps {
+  className?: string;
+}
+
+export default function SideMenu({ className }: SideMenuProps) {
+  return (
+    <Card className={clsx('w-80 md:w-44 lg:w-72 px-4 py-6 flex flex-col gap-4', className)}>
+      {/* 프로필 영역 */}
+      <div className='relative flex justify-center mt-4 w-[120px] h-[120px] md:w-[70px] md:h-[70px] lg:w-[120px] lg:h-[120px] mx-auto'>
+        <Image src='/images/icons/default_profile.svg' alt='Profile' width={120} height={120} />
+        <RoundButton
+          mode='edit'
+          className='absolute bottom-[8px] right-[4px] md:bottom-[4px] md:right-[0px] lg:bottom-[8px] lg:right-[4px]'
+        />
+      </div>
+
+      {/* 메뉴 리스트 */}
+      <nav className='flex flex-col gap-3 md:gap-1'>
+        <Button
+          asChild
+          variant='ghost'
+          className='group hover:bg-primary-100 justify-start gap-2 py-6.5 px-10 text-grayscale-600 text-base'
+        >
+          <Link href='/mypage/user'>
+            <FaUser className='h-4 w-4 group-hover:text-primary-500' />내 정보
+          </Link>
+        </Button>
+
+        <Button
+          asChild
+          variant='ghost'
+          className='group hover:bg-primary-100 justify-start gap-2 py-6.5 text-grayscale-600 text-base'
+        >
+          <Link href='/mypage/reservation-list'>
+            <FaCommentDots className='h-4 w-4 group-hover:text-primary-500' />
+            예약내역
+          </Link>
+        </Button>
+
+        <Button
+          asChild
+          variant='ghost'
+          className='group hover:bg-primary-100 justify-start gap-2 py-6.5 text-grayscale-600 text-base'
+        >
+          <Link href='/mypage/my-experience'>
+            <FaCog className='h-4 w-4 group-hover:text-primary-500' /> 내 체험 관리
+          </Link>
+        </Button>
+
+        <Button
+          asChild
+          variant='ghost'
+          className='group hover:bg-primary-100 justify-start gap-2 py-6.5 text-grayscale-600 text-base'
+        >
+          <Link href='/mypage/reservation-status'>
+            <FaCalendarAlt className='h-4 w-4 group-hover:text-primary-500' />
+            예약 현황
+          </Link>
+        </Button>
+      </nav>
+    </Card>
+  );
+}

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -1,0 +1,55 @@
+import * as React from 'react';
+
+import { cn } from '@/lib/utils/shadCnUtils';
+
+const Card = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => (
+    <div
+      ref={ref}
+      className={cn('rounded-xl border bg-card text-card-foreground shadow', className)}
+      {...props}
+    />
+  ),
+);
+Card.displayName = 'Card';
+
+const CardHeader = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => (
+    <div ref={ref} className={cn('flex flex-col space-y-1.5 p-6', className)} {...props} />
+  ),
+);
+CardHeader.displayName = 'CardHeader';
+
+const CardTitle = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => (
+    <div
+      ref={ref}
+      className={cn('font-semibold leading-none tracking-tight', className)}
+      {...props}
+    />
+  ),
+);
+CardTitle.displayName = 'CardTitle';
+
+const CardDescription = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => (
+    <div ref={ref} className={cn('text-sm text-muted-foreground', className)} {...props} />
+  ),
+);
+CardDescription.displayName = 'CardDescription';
+
+const CardContent = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => (
+    <div ref={ref} className={cn('p-6 pt-0', className)} {...props} />
+  ),
+);
+CardContent.displayName = 'CardContent';
+
+const CardFooter = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => (
+    <div ref={ref} className={cn('flex items-center p-6 pt-0', className)} {...props} />
+  ),
+);
+CardFooter.displayName = 'CardFooter';
+
+export { Card, CardHeader, CardFooter, CardTitle, CardDescription, CardContent };


### PR DESCRIPTION
# 📦 Pull Request

## 📝 요약(Summary)

<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
- 내 체험 관리 페이지 내 사이드 메뉴 컴포넌트를 작업하였습니다. (`SideMenu.tsx`)
- RoundButton 컴포넌트 내 수정 버튼 추가 (`RoundButton.tsx`)
- shadCn Card ui를 추가하였습니다.

## 💬 공유사항 to 리뷰어

<!--
이 PR에서 집중적으로 리뷰 받고 싶은 부분이나
논의가 필요한 사항을 작성해주세요.
예시: 함수명, 컴포넌트 구조, 성능 최적화 아이디어 등
-->
- SideMenu 컴포넌트만 확인해주시면 될 것 같습니다. 다른 파일은 페이지 구조 추가입니다.

## 📸 스크린샷

<!-- UI/UX 변경 시 필수로 첨부 -->
<img width="1920" height="911" alt="screencapture-localhost-3000-mypage-reservation-status-2025-08-30-17_02_03" src="https://github.com/user-attachments/assets/aaa0d5f2-4dc0-45b8-9feb-bd294b0724c0" />




https://github.com/user-attachments/assets/0a7955e1-a74a-40f5-b90c-6a7082111469

