### PR TITLE
feat TRI-39: 검색시 지도 추가 

### DIFF
--- a/src/components/common/Nav.tsx
+++ b/src/components/common/Nav.tsx
@@ -18,15 +18,17 @@ export default function Nav() {
   const { isMobile, isTablet } = useScreenSize();
   const [isSearching, setIsSearching] = useState(false);
 
+  const cappedScrollY = useTransform(scrollY, (v) => Math.min(v, 80));
+
   // 스크롤 위치에 따른 애니메이션 원본 값 (raw values)
   const rawStackHeight = useTransform(
-    scrollY,
+    cappedScrollY,
     [0, 40, 80],
     [CATEGORY_H + GAP + SEARCH_H, SEARCH_H, SEARCH_H],
   );
-  const rawCategoryY = useTransform(scrollY, [0, 40, 80], [0, -CATEGORY_H, -CATEGORY_H]);
-  const rawCategoryOpacity = useTransform(scrollY, [0, 40, 80], [1, 0, 0]);
-  const rawSearchY = useTransform(scrollY, [0, 30, 80], [90, 10, 25]);
+  const rawCategoryY = useTransform(cappedScrollY, [0, 40, 80], [0, -CATEGORY_H, -CATEGORY_H]);
+  const rawCategoryOpacity = useTransform(cappedScrollY, [0, 40, 80], [1, 0, 0]);
+  const rawSearchY = useTransform(cappedScrollY, [0, 30, 80], [90, 10, 25]);
 
   // spring easing 적용 (자연스러운 애니메이션)
   const springConfig = { stiffness: 300, damping: 35, mass: 0.5 };

--- a/src/components/home/ActivityLike.tsx
+++ b/src/components/home/ActivityLike.tsx
@@ -9,9 +9,15 @@ interface FavoriteButtonProps {
   activity: Activity;
   userId: number;
   size?: number;
+  isButton?: boolean;
 }
 
-export default function ActivityLike({ activity, userId, size = 28 }: FavoriteButtonProps) {
+export default function ActivityLike({
+  activity,
+  userId,
+  size = 28,
+  isButton = false,
+}: FavoriteButtonProps) {
   const { initializeUser, isFavorite, toggleFavorite } = useFavoritesStore();
 
   // 사용자 초기화 (userId가 바뀔 때마다 실행)
@@ -25,12 +31,14 @@ export default function ActivityLike({ activity, userId, size = 28 }: FavoriteBu
     <button
       onClick={() => toggleFavorite(activity)}
       aria-label={isLiked ? '찜 해제하기' : '찜하기'}
-      className='absolute top-[12px] right-[16px] w-[32px] h-[32px] text-white cursor-pointer'
+      className={`absolute top-[12px] right-[16px] w-[32px] h-[32px] flex justify-center items-center text-white cursor-pointer ${isButton ? 'bg-gray-200 rounded-full' : ''}`}
     >
       <Heart
         size={size}
-        fill={isLiked ? 'var(--primary-400)' : 'rgba(0, 0, 0, 0.8)'}
-        stroke='white'
+        fill={
+          isLiked ? 'var(--primary-400)' : isButton ? 'var(--color-gray-200)' : 'rgba(0, 0, 0, 0.8)'
+        }
+        stroke={isButton ? 'black' : 'white'}
         strokeWidth={1.5}
         strokeLinejoin='round'
         strokeLinecap='round'

--- a/src/components/home/ActivitySheet.tsx
+++ b/src/components/home/ActivitySheet.tsx
@@ -97,7 +97,7 @@ export default function ActivitySheet({
   if (!fullHeight) return null;
 
   return (
-    <div className='flex items-center justify-center'>
+    <div className='flex items-center justify-center z-[110]'>
       <motion.div
         ref={sheetRef}
         className='fixed left-0 right-0 bottom-0 bg-white rounded-t-2xl shadow-lg'

--- a/src/components/home/BottomNav.tsx
+++ b/src/components/home/BottomNav.tsx
@@ -64,7 +64,7 @@ export default function BottomNav() {
   return (
     <>
       <motion.nav
-        className='fixed bottom-0 left-0 right-0 flex items-center justify-center w-full h-[82px] z-50 bg-gradient-to-b from-white to-gray-50 border-b border-grayscalescale-20 border-t shadow-md'
+        className='fixed bottom-0 left-0 right-0 flex items-center justify-center w-full h-[82px] z-[120] bg-gradient-to-b from-white to-gray-50 border-b border-grayscalescale-20 border-t shadow-md'
         animate={{ y: visible ? 0 : 82 }} // translate-y 대신 y로
         transition={{ type: 'spring', stiffness: 300, damping: 30 }} // 스프링 효과
       >

--- a/src/components/home/MapCard.tsx
+++ b/src/components/home/MapCard.tsx
@@ -1,0 +1,120 @@
+'use client';
+
+import Link from 'next/link';
+import Image from 'next/image';
+import { useState } from 'react';
+import { Activity } from '@/types/activities.type';
+import { useUserStore } from '@/store/userStore';
+import { BASE_IMG_URL } from './Constants';
+import { X } from 'lucide-react';
+import ActivityLike from './ActivityLike';
+import { useScreenSize } from '@/hooks/useScreenSize';
+
+interface MapCardProps {
+  activity: Activity;
+  onClose: () => void; // 닫기 콜백
+}
+
+export default function MapCard({ activity, onClose }: MapCardProps) {
+  const [isError, setIsError] = useState(false);
+  const { isDesktop } = useScreenSize();
+
+  const user = useUserStore((state) => state.user);
+
+  const bannerImg = isError ? BASE_IMG_URL : activity.bannerImageUrl;
+
+  return (
+    <>
+      {isDesktop ? (
+        <div
+          className={`group absolute left-10 block w-[327px] h-auto rounded-2xl overflow-hidden shadow-lg bg-white transition-transform hover:scale-105 ${isDesktop ? 'top-10 ' : 'top-30'}`}
+        >
+          {/* 닫기 버튼 */}
+          {user && (
+            <button
+              type='button'
+              onClick={onClose}
+              className='absolute right-10 z-[200] w-8 h-8 flex items-center justify-center rounded-full transition'
+            >
+              <ActivityLike activity={activity} userId={user.id} size={20} isButton={true} />
+            </button>
+          )}
+          <button
+            type='button'
+            onClick={onClose}
+            className='absolute top-[12px] right-[12px] z-[200] w-8 h-8 flex items-center justify-center rounded-full bg-gray-200 text-gray-700 hover:bg-gray-300 transition'
+          >
+            <X width={16} height={16} />
+          </button>
+
+          {/* 링크 + 이미지 */}
+          <Link href={`/activities/${activity.id}`}>
+            <div className='w-full h-[200px] relative'>
+              <Image
+                src={bannerImg}
+                alt={activity.title}
+                fill
+                className='object-cover'
+                onError={() => setIsError(true)}
+                blurDataURL={BASE_IMG_URL}
+                loading='lazy'
+              />
+            </div>
+          </Link>
+
+          {/* 설명 */}
+          <div className='p-4 flex flex-col gap-2'>
+            <h3 className='text-16-semibold text-title'>{activity.title}</h3>
+            <p className='text-13-regular text-subtitle line-clamp-2'>{activity.description}</p>
+            <span className='text-14-bold text-title'>{activity.price?.toLocaleString()}원</span>
+          </div>
+        </div>
+      ) : (
+        <div className='group absolute top-15 left-1/2 w-11/12 max-w-[470px] h-[126px] rounded-2xl overflow-hidden shadow-lg bg-white flex -translate-x-1/2'>
+          {/* 이미지 영역 */}
+          <Link href={`/activities/${activity.id}`}>
+            <div className='w-[126px] h-full relative flex-shrink-0'>
+              <Image
+                src={bannerImg}
+                alt={activity.title}
+                fill
+                className='object-cover rounded-l-2xl'
+                onError={() => setIsError(true)}
+                blurDataURL={BASE_IMG_URL}
+                loading='lazy'
+              />
+            </div>
+          </Link>
+
+          {/* 설명 영역 */}
+          <div className='flex-1 p-3 flex flex-col justify-between'>
+            <div>
+              <h3 className='text-14-semibold text-title line-clamp-2'>{activity.title}</h3>
+              <p className='text-12-regular text-subtitle line-clamp-2'>{activity.description}</p>
+            </div>
+            <span className='text-13-bold text-title'>{activity.price?.toLocaleString()}원</span>
+          </div>
+
+          {/* 닫기 버튼 */}
+          <button
+            type='button'
+            onClick={onClose}
+            className='absolute top-2 right-2 z-[200] w-6 h-6 flex items-center justify-center rounded-full bg-gray-200 text-gray-700 hover:bg-gray-300 transition'
+          >
+            <X width={14} height={14} />
+          </button>
+
+          {/* 좋아요 버튼 */}
+          {user && (
+            <button
+              type='button'
+              className='absolute top-2 right-10 z-[200] w-6 h-6 flex items-center justify-center rounded-full transition'
+            >
+              <ActivityLike activity={activity} userId={user.id} size={16} isButton />
+            </button>
+          )}
+        </div>
+      )}
+    </>
+  );
+}

--- a/src/components/home/SearchResult.tsx
+++ b/src/components/home/SearchResult.tsx
@@ -2,8 +2,13 @@
 
 import { Activity } from '@/types/activities.type';
 import { useScreenSize } from '@/hooks/useScreenSize';
+import { useInfiniteList } from '@/hooks/useInfiniteList';
+import NaverMap from '../common/naverMaps/NaverMap';
+import Marker from '../common/naverMaps/Marker';
 import ActivitySheet from './ActivitySheet';
 import ActivityList from './ActivityList';
+import { useState } from 'react';
+import MapCard from './MapCard';
 
 export default function SearchResult({
   initialActivities,
@@ -14,19 +19,81 @@ export default function SearchResult({
   initalCursorId: number;
   totalCount: number;
 }) {
+  const [activeMarkerId, setActiveMarkerId] = useState<number | null>(null);
+
   const { isDesktop } = useScreenSize();
+
+  const { allActivities } = useInfiniteList(initialActivities, initalCursorId);
+
+  const initAddress = '서울특별시 종로구 세종대로 172';
 
   return (
     <>
-      <div className='grid grid-cols-1 xl:grid-cols-[3fr_2fr] h-screen'>
+      <div className='grid grid-cols-1 xl:grid-cols-[4fr_3fr] h-auto text-white'>
         {isDesktop ? (
           <>
-            <ActivityList initialActivities={initialActivities} initalCursorId={initalCursorId} />
-            <div>여기에 지도가 표시됩니다</div>
+            <div className=''>
+              <ActivityList initialActivities={initialActivities} initalCursorId={initalCursorId} />
+            </div>
+
+            {/* 우측: 스크롤 고정 */}
+            <div className='h-screen sticky top-0'>
+              <NaverMap address={initAddress} height='100%' zoom={11}>
+                {allActivities.map((activity, index) => (
+                  <Marker
+                    key={activity.id}
+                    address={activity.address!}
+                    id={`price-marker-${index}`}
+                    onClick={() => {
+                      setActiveMarkerId(activity.id);
+                    }}
+                  >
+                    <div
+                      className='px-3 py-1 max-w-[100px] bg-gray-100 text-gray-600 text-[13px] font-semibold rounded-2xl
+             transition-transform duration-200 ease-in-out hover:scale-105 shadow-lg'
+                    >
+                      {activity.price.toLocaleString()}원
+                    </div>
+                  </Marker>
+                ))}
+              </NaverMap>
+              {activeMarkerId !== null && (
+                <MapCard
+                  activity={allActivities.find((a) => a.id === activeMarkerId)!}
+                  onClose={() => setActiveMarkerId(null)}
+                />
+              )}
+            </div>
           </>
         ) : (
           <>
-            <div>여기에 지도가 표시됩니다</div>
+            <div className='h-screen sticky top-0'>
+              <NaverMap address={initAddress} height='100%' zoom={11}>
+                {allActivities.map((activity, index) => (
+                  <Marker
+                    key={activity.id}
+                    address={activity.address!}
+                    id={`price-marker-${index}`}
+                    onClick={() => {
+                      setActiveMarkerId(activity.id);
+                    }}
+                  >
+                    <div
+                      className='px-3 py-1 bg-gray-100 text-gray-600 text-[13px] font-semibold rounded-2xl
+             transition-transform duration-200 ease-in-out hover:scale-105 shadow-lg'
+                    >
+                      {activity.price.toLocaleString()}원
+                    </div>
+                  </Marker>
+                ))}
+              </NaverMap>
+              {activeMarkerId !== null && (
+                <MapCard
+                  activity={allActivities.find((a) => a.id === activeMarkerId)!}
+                  onClose={() => setActiveMarkerId(null)}
+                />
+              )}
+            </div>
             <ActivitySheet totalCount={totalCount}>
               <ActivityList initialActivities={initialActivities} initalCursorId={initalCursorId} />
             </ActivitySheet>


### PR DESCRIPTION
# 검색시 지도 추가 

## 데스크탑
<img width="1677" height="924" alt="스크린샷 2025-09-02 오후 8 08 34" src="https://github.com/user-attachments/assets/2e1f8293-6942-4c14-b84e-d2f8327d009d" />

## 테블릿
<img width="799" height="598" alt="스크린샷 2025-09-02 오후 8 08 54" src="https://github.com/user-attachments/assets/de499ab6-fb5e-4cc2-90aa-6acaebaa85e6" />

## 모바일
<img width="369" height="598" alt="스크린샷 2025-09-02 오후 8 09 06" src="https://github.com/user-attachments/assets/2d3edc10-3455-415d-91cd-5122d9e383a6" />


## 동작 구현 이슈 


https://github.com/user-attachments/assets/7ec8b329-58da-46fc-a744-26a48879001d


생각했던 구현 방식은 

마커 클릭시 해당 마커에 relative 된 상태를 원했으나 현재는 absoulte 상태로 구현 

마커의 x,y 값을 구할수 있는지가 중요할듯 만약 안된다면 다른 디자인이나 방식을 사용할 수도 있을것 같음


activity리스트가 추가될때, 마커 클릭을 통해 모달 생성/삭제 시 지도 화면이 깜빡이는 문제가 발생. 

해결을 하기위해 마커나 지도를 메모이제이션 해보려 했으나 실패함...ㅠㅠ
