### PR TITLE
Fix: 로그인 후 다이랙트 경로 설정 

### DIFF
--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -35,27 +35,6 @@ const Login = () => {
     },
   });
 
-  // 로그인 성공 시 다이랙트 설정
-  // const params = new URLSearchParams(window.location.search);
-  // const redirectUrl = params.get('redirect');
-  // const source = params.get('source');
-
-  // const handleLoginSuccess = () => {
-  //   console.log(source);
-  //   alert(source);
-
-  //   if (source === 'signup') {
-  //     // 회원가입 페이지를 통해 왔다면 무조건 메인 페이지로 이동
-  //     router.push('/');
-  //   } else if (redirectUrl) {
-  //     // 리다이렉트 URL이 있다면 해당 페이지로 이동
-  //     router.push(redirectUrl);
-  //   } else {
-  //     // 리다이렉트 URL이 없다면 기본 페이지(메인)로 이동
-  //     router.push('/');
-  //   }
-  // };
-
   // 로그인 요청 mutation
   const mutation = useMutation({
     mutationFn: login,
@@ -64,11 +43,15 @@ const Login = () => {
       const user = await getUserInfo();
       setUser(user);
 
-      router.push('/');
+      setTimeout(() => {
+        const redirectUrl = sessionStorage.getItem('redirectUrl');
+        if (redirectUrl) {
+          sessionStorage.removeItem('redirectUrl');
+          router.replace(redirectUrl);
+        }
 
-      // handleLoginSuccess();
-
-      successToast.run(`${user.nickname}님 환영합니다!`);
+        successToast.run(`${user.nickname}님 환영합니다!`);
+      }, 0);
     },
     onError: (err: unknown) => {
       const error = err as AxiosError<{ message: string }>;

--- a/src/app/signup/page.tsx
+++ b/src/app/signup/page.tsx
@@ -65,7 +65,6 @@ const SignUp = () => {
             type: 'server',
             message: error.response?.data.message,
           });
-
           handled = true;
         }
 

--- a/src/components/home/LoginSection.tsx
+++ b/src/components/home/LoginSection.tsx
@@ -11,6 +11,7 @@ import { useNotifications } from '@/hooks/useNotification';
 import Link from 'next/link';
 import Image from 'next/image';
 import NotificationModal from './NotificationModal';
+import { useSaveCurrentUrl } from '@/lib/utils/useSaveCurrentUrl';
 
 export default function LoginSection() {
   const { isDesktop } = useScreenSize();
@@ -19,6 +20,8 @@ export default function LoginSection() {
   const [isModalOpen, setIsModalOpen] = useState(false);
 
   const user = useUserStore((state) => state.user);
+
+  const saveCurrentUrl = useSaveCurrentUrl();
 
   if (user) {
     return (
@@ -62,13 +65,14 @@ export default function LoginSection() {
     <>
       {isDesktop && (
         <Link
+          onClick={saveCurrentUrl}
           href='/login'
           className='px-4 py-2 hover:border rounded-full hover:bg-grayscale-50 transition-soft text-14-regular text-title'
         >
           로그인 하기
         </Link>
       )}
-      <Link href='/login' className='cursor-pointer'>
+      <Link onClick={saveCurrentUrl} href='/login' className='cursor-pointer'>
         <Image src='/images/icons/default_profile_gray.svg' alt='Profile' width={30} height={30} />
       </Link>
     </>

--- a/src/lib/utils/useSaveCurrentUrl.ts
+++ b/src/lib/utils/useSaveCurrentUrl.ts
@@ -1,0 +1,14 @@
+import { usePathname, useSearchParams } from 'next/navigation';
+
+// 현재 URL sessionStorage에 저장
+export const useSaveCurrentUrl = () => {
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+
+  const saveCurrentUrlAndGoLogin = () => {
+    const currentUrl = `${pathname}${searchParams.toString() ? `?${searchParams.toString()}` : ''}`;
+    sessionStorage.setItem('redirectUrl', currentUrl);
+  };
+
+  return saveCurrentUrlAndGoLogin;
+};


### PR DESCRIPTION
# 📦 Pull Request

## 📝 요약(Summary)

기존에는 로그인 완료 시 항상 메인 페이지로 이동하는 문제로 인해 불편함이 존재
사용자가 로그인 페이지로 이동하기 전 머물던 경로를 `sessionStorage`에 저장하고 로그인 성공 후 해당 경로로 복귀할 수 있도록 개선
저장된 경로가 없으면 메인 페이지로 이동

<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

## 💬 공유사항 to 리뷰어
`home/LoginSection.tsx` 에서 사용자가 머물던 경로를 저장할 수 있도록 onClick 이벤트를 추가하였습니다.

<!--
이 PR에서 집중적으로 리뷰 받고 싶은 부분이나
논의가 필요한 사항을 작성해주세요.
예시: 함수명, 컴포넌트 구조, 성능 최적화 아이디어 등
-->

## 📸 스크린샷

<!-- UI/UX 변경 시 필수로 첨부 -->
