### PR TITLE
Fix: axios인스턴스 401 에러 객체 반환

### DIFF
--- a/src/app/api/axiosInstance.ts
+++ b/src/app/api/axiosInstance.ts
@@ -3,23 +3,26 @@ import { useUserStore } from '@/store/userStore';
 import { errorToast } from '@/lib/utils/toastUtils';
 import { BASE_URL } from './config';
 
+// 실패한 요청들을 큐에 저장할 때 사용하는 타입 정의
 interface FailedRequest {
   resolve: (value?: unknown) => void;
   reject: (error?: AxiosError | unknown) => void;
 }
 
-let isRefreshing = false;
-let failedQueue: FailedRequest[] = []; // API 대기하는 요청 큐
+let isRefreshing = false; // 현재 토큰 갱신 중인지 확인 & 동시에 여러 요청 중복 갱신 방지
+let failedQueue: FailedRequest[] = []; // 토큰 갱신 중일 때 대기해야 하는 API 요청을 저장하는 큐
 
 /**
  * 큐에 쌓인 요청들을 처리합니다.
- * @param error - 에러가 발생한 경우, 에러 객체를 전달합니다.
+ * 토큰 갱신 성공 시 → 모든 대기 요청을 다시 실행
+ * 토큰 갱신 실패 시 → 모든 대기 요청을 에러로 처리
  */
 const processQueue = (error: AxiosError | null) => {
   failedQueue.forEach(({ resolve, reject }) => (error ? reject(error) : resolve()));
   failedQueue = [];
 };
 
+// axios 인스턴스 생성
 const axiosInstance = axios.create({
   baseURL: BASE_URL,
   timeout: 10000,
@@ -27,27 +30,39 @@ const axiosInstance = axios.create({
   withCredentials: true,
 });
 
-// 요청 인터셉터: 401 에러 처리
+// 응답 인터셉터 등록
 axiosInstance.interceptors.response.use(
   (response) => response,
-  async (error: AxiosError) => {
-    // 에러 발생 시 config 객체가 없을 때
-    if (!error.config) return Promise.reject(error);
 
-    // 타입 에러를 해결하기 위해 `InternalAxiosRequestConfig` 타입 사용
+  // 에러 응답 처리 함수
+  async (error: AxiosError) => {
+    if (!error.config) {
+      console.error('Axios error without config:', error);
+      return Promise.reject(error);
+    }
+
+    // _retry: 이미 재시도했는지 확인하는 플래그 (무한 루프 방지)
     const originalRequest: InternalAxiosRequestConfig & { _retry?: boolean } = error.config;
 
-    // HTTP 상태 코드가 401이고, 재시도 플래그가 없는 경우
+    // HTTP 401 에러이고, 아직 재시도하지 않은 요청인 경우에만 처리
     if (error.response?.status === 401 && !originalRequest._retry) {
-      originalRequest._retry = true;
+      originalRequest._retry = true; // 재시도 플래그 설정 (같은 요청 재시도x)
 
-      // 로그인하지 않은 경우 refresh 토큰 갱신 시도하지 않음
+      // 🔍 로그인하지 않은 사용자의 무한 루프 방지
+      // 사용자가 로그인하지 않은 상태라면 refresh 토큰도 없으므로
+      // 갱신 시도 없이 바로 로그인 필요 에러 반환
       const user = useUserStore.getState().user;
       if (!user) {
-        return Promise.reject(error);
+        return Promise.reject({
+          message: '로그인이 필요합니다.',
+          status: 401,
+          code: 'LOGIN_REQUIRED',
+          name: 'AuthError',
+        });
       }
 
-      // 클라이언트일 때만 큐 처리
+      // 🔄 동시성 처리: 이미 다른 요청이 토큰 갱신 중이라면
+      // 현재 요청을 큐에 추가하고 갱신 완료를 기다림
       if (isRefreshing) {
         return new Promise((resolve, reject) => {
           failedQueue.push({
@@ -59,32 +74,40 @@ axiosInstance.interceptors.response.use(
       isRefreshing = true;
 
       try {
-        // 인터셉터 없는 인스턴스로 refresh-token 호출
+        // 🚨 인터셉터가 없는 별도의 axios 인스턴스 생성
+        // 현재 인스턴스를 사용하면 refresh-token 요청도 인터셉터를 거쳐서
+        // 401이 발생하면 또 다시 이 코드가 실행되는 순환 참조 발생
         const plainAxios = axios.create({
           baseURL: BASE_URL,
           withCredentials: true,
           headers: { 'Content-Type': 'application/json' },
         });
 
-        // refreshToken은 HttpOnly라서 클라이언트에서 못 읽음
-        // 프록시 서버에서 처리하도록 요청
+        // 서버에 refresh-token 요청
+        // refreshToken은 HttpOnly 쿠키에 저장되어 있어서
+        // 클라이언트에서 직접 읽을 수 없고, 브라우저가 자동으로 전송
         await plainAxios.post('/auth/refresh-token');
 
+        // 🎉 토큰 갱신 성공 : 큐에 대기 중인 모든 요청들을 성공 처리
         processQueue(null);
 
-        // 큐 대기 처리
+        // 원본 요청을 새로운 토큰으로 다시 실행
         return axiosInstance(originalRequest);
       } catch (error) {
+        // 토큰 갱신 실패 (refresh token도 만료되었거나 유효하지 않음)
         const refreshError = error as AxiosError;
+
+        // 큐에 대기 중인 모든 요청들을 에러로 처리
         processQueue(refreshError);
 
-        // 쿠키 삭제 + 유저 정보 삭제
+        // 🧹 로그아웃 처리
+        // 서버에서 쿠키 삭제 요청, 상태 관리 유저 정보 삭제
         fetch('/api/logout', { method: 'POST' }).catch(() => {});
-
         useUserStore.getState().clearUser();
 
         errorToast.run('로그인 세션이 만료되었습니다.');
 
+        // 4. 로그인 페이지로 리다이렉트 (약간의 지연 후)
         setTimeout(() => {
           const currentPath = window.location.pathname;
 
@@ -94,11 +117,20 @@ axiosInstance.interceptors.response.use(
           }
         }, 800);
 
-        return Promise.reject(refreshError);
+        // 에러 객체 반환
+        return Promise.reject({
+          message: '로그인 세션이 만료되었습니다.',
+          status: 401,
+          code: 'SESSION_EXPIRED',
+          name: 'SessionExpiredError',
+          originalError: refreshError,
+        });
       } finally {
+        // 토큰 갱신 프로세스 종료
         isRefreshing = false;
       }
     }
+    // 401이 아니거나 이미 재시도한 요청은 그대로 에러 반환
     return Promise.reject(error);
   },
 );


### PR DESCRIPTION
# 📦 Pull Request

## 📝 요약(Summary)

로그인 및 로그인 세션 만료 시 에러 메시지와 상태 코드를 함께 객체로 반환하도록 수정했습니다.

<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

## 💬 공유사항 to 리뷰어
401 에러가 뜨면 관련 모달이 뜨지 않는 거 같아서 확인 필요

<!--
이 PR에서 집중적으로 리뷰 받고 싶은 부분이나
논의가 필요한 사항을 작성해주세요.
예시: 함수명, 컴포넌트 구조, 성능 최적화 아이디어 등
-->

## 📸 스크린샷
<img width="912" height="540" alt="image" src="https://github.com/user-attachments/assets/8b7a1ab4-a3c7-4d60-84dd-4b4e36bf626c" />


<!-- UI/UX 변경 시 필수로 첨부 -->
